### PR TITLE
Bump version 7.16.2 / Log4j fix applied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:11-jre-slim
 
 LABEL maintainer "nshou <nshou@coronocoya.net>"
 
-ENV EK_VERSION=7.12.1
+ENV EK_VERSION=7.16.2
 
 RUN apt-get update -qq >/dev/null 2>&1 \
  && apt-get install wget sudo -qqy >/dev/null 2>&1 \


### PR DESCRIPTION
This bumps ElasticSearch and Kibana to the latest version with the log4j exploit fixed.

Tested on Docker and on Kubernetes 1.22.0

LGTM