### PR TITLE
tweak: Patch angry `JAVA_HOME` message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:11-jre-slim
 LABEL maintainer "nshou <nshou@coronocoya.net>"
 
 ENV EK_VERSION=7.16.2
+ENV ES_JAVA_HOME=/usr/local/openjdk-11/
 
 RUN apt-get update -qq >/dev/null 2>&1 \
  && apt-get install wget sudo -qqy >/dev/null 2>&1 \


### PR DESCRIPTION
Title, the goal is to make Elastic/Kibana no longer upset when running on Production.

Java version fix for GC Sweep as well would be bumping to Version 17+ however untested at the moment.


Tests passing