### PR TITLE
tweak: Update `Dockerfile` to silence Java warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:11-jre-slim
 LABEL maintainer "nshou <nshou@coronocoya.net>"
 
 ENV EK_VERSION=7.16.2
+ENV ES_JAVA_HOME=/usr/local/openjdk-11
 
 RUN apt-get update -qq >/dev/null 2>&1 \
  && apt-get install wget sudo -qqy >/dev/null 2>&1 \


### PR DESCRIPTION
Simple merge, this tweak just silences the warning from Elasticsearch mentioning it's missing an optional environment variable describing Java's home location.