### PR TITLE
fix: Broken session output after first start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ LABEL maintainer "nshou <nshou@coronocoya.net>"
 # Elasticsearch / Kibana Stack version.
 ENV EK_VERSION=8.10.4
 
-# Enable Security for Elasticsearch / Kibana
+# Enable Security for Elasticsearch / Kibana.
 ENV SSL_MODE=true
+
+# Elasticsearch 'elastic' superuser password.
+ENV ELASTIC_NEW_PASSWORD=mysupersecretpassword
 
 RUN apt-get update -qq >/dev/null 2>&1 \
     && apt-get install wget unzip curl sudo -qqy >/dev/null 2>&1 \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ elasticsearch-${EK_VERSION}/bin/elasticsearch-reset-password \
       --url "https://localhost:9200" \
       -u elastic \
       -b \
+      -i \
       -E xpack.security.http.ssl.enabled=true \
       -E xpack.security.http.ssl.certificate=/home/elastic/elasticsearch-${EK_VERSION}/config/certs/instance/instance.crt \
       -E xpack.security.http.ssl.key=/home/elastic/elasticsearch-${EK_VERSION}/config/certs/instance/instance.key \

--- a/README.md
+++ b/README.md
@@ -2,20 +2,46 @@
 
 Simple and lightweight docker image for previewing Elasticsearch and Kibana.
 
+You can connect to Elasticsearch through https://localhost:9200 and explore Kibana via https://localhost:5601
+
+The password for the instance will be output to the console at first launch.
+
 ### Usage
+*Dockerhub*
 ```bash
 docker run -d -p 9200:9200 -p 5601:5601 nshou/elasticsearch-kibana
 ```
 
-### SSL / TLS Mode
-You can toggle SSL/TLS mode with the `SSL_MODE` ENV parameter. **(Enabled by default)**
+*Github Container Registry*
 ```bash
-docker run -d -p 9200:9200 -p 5601:5601 -e SSL_MODE=false nshou/elasticsearch-kibana
+docker run -d -p 9200:9200 -p 5601:5601 ghcr.io/nshou/elasticsearch-kibana
 ```
 
-You can connect to Elasticsearch through `localhost:9200` and explore Kibana via `localhost:5601`.
+---
 
-The password for the instance will be output to the console at first launch.
+### Resetting `elastic` user password
+If for some reason your password does not get shows as being reset in the console you can run the following command inside of the container.
+```bash
+elasticsearch-${EK_VERSION}/bin/elasticsearch-reset-password \
+      -v \
+      --url "https://localhost:9200" \
+      -u elastic \
+      -b \
+      -E xpack.security.http.ssl.enabled=true \
+      -E xpack.security.http.ssl.certificate=/home/elastic/elasticsearch-${EK_VERSION}/config/certs/instance/instance.crt \
+      -E xpack.security.http.ssl.key=/home/elastic/elasticsearch-${EK_VERSION}/config/certs/instance/instance.key \
+      -E xpack.security.http.ssl.certificate_authorities=/home/elastic/elasticsearch-${EK_VERSION}/config/certs/ca/ca.crt
+```
+
+### Enable/Disable Security Features
+If you wish to run this image with no security features enabled, you can toggle SSL/TLS mode with the `SSL_MODE` ENV parameter.
+```bash
+# Docker Image
+docker run -d -p 9200:9200 -p 5601:5601 -e SSL_MODE=false nshou/elasticsearch-kibana
+
+# Github Container Registry
+docker run -d -p 9200:9200 -p 5601:5601 -e SSL_MODE=false ghcr.io/nshou/elasticsearch-kibana
+```
 
 ### Tags
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,11 +115,9 @@ if [[ "${SSL_MODE}" == "true" ]]; then
       );
       exit_code=$?
       if [ $exit_code -eq 0 ]; then
-
+      
         # Generate new password and grab the value from 'awk'
-        ELASTIC_NEW_PASSWORD=$(echo "$ELASTIC_RANDOM_PASSWORD" | awk '/New value:/ {print $3}');    
-
-        clear
+        ELASTIC_NEW_PASSWORD=$(echo "$ELASTIC_RANDOM_PASSWORD" | awk '/New value:/ {print $3}');
         echo "----------------------------------------------------------------------------------"
         echo "Elasticsearch + Kibana is now fully configured, you may access the stack below"
         echo "     URL: https://localhost:5601/"
@@ -135,7 +133,6 @@ if [[ "${SSL_MODE}" == "true" ]]; then
     fi
   done &
 
-  # Start Kibana in SSL mode
   kibana-${EK_VERSION}/bin/kibana \
     -Q \
     --allow-root \
@@ -150,6 +147,7 @@ if [[ "${SSL_MODE}" == "true" ]]; then
     --elasticsearch.ssl.key=/home/elastic/elasticsearch-${EK_VERSION}/config/certs/instance/instance.key \
     --elasticsearch.ssl.verificationMode=certificate \
     --elasticsearch.serviceAccountToken=${KIBANA_SERVICE_TOKEN}
+  # Start Kibana in SSL Mode
 
 elif [[ "${SSL_MODE}" == "false" ]]; then
   # Show the connection URLS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,8 +59,6 @@ if [[ ! -f /home/elastic/cert_bundle.zip ]]; then
   unzip -qq /home/elastic/kibana_cert_bundle.zip -d /home/elastic/kibana-${EK_VERSION}/ #unzips as 'ca/'
 
   # ----------------------------
-
-  # ----------------------------
   # AUTHENTICATION SETUP
   # ----------------------------
 
@@ -82,7 +80,10 @@ echo "SSL ENABLED: '${SSL_MODE}'"
 echo "----------------------------------------------------------------------------------"
 
 if [[ "${SSL_MODE}" == "true" ]]; then
-  #Start Elasticsearch in SSL mode
+  # ----------------------------
+  # Start Elastic / Kibana [SSL]
+  # ----------------------------
+  
   elasticsearch-${EK_VERSION}/bin/elasticsearch \
     --quiet \
     -E http.host=0.0.0.0 \
@@ -115,18 +116,17 @@ if [[ "${SSL_MODE}" == "true" ]]; then
       );
       exit_code=$?
       if [ $exit_code -eq 0 ]; then
-      
-        # Generate new password and grab the value from 'awk'
+        # Random password for Elastic
         ELASTIC_NEW_PASSWORD=$(echo "$ELASTIC_RANDOM_PASSWORD" | awk '/New value:/ {print $3}');
+
+        # Output password details to console post-start
         echo "----------------------------------------------------------------------------------"
         echo "Elasticsearch + Kibana is now fully configured, you may access the stack below"
         echo "     URL: https://localhost:5601/"
         echo "    User: 'elastic'"
         echo "Password: '$ELASTIC_NEW_PASSWORD'"
         echo "----------------------------------------------------------------------------------"
-
-        # Flip global check value to stop this loop
-        password_reset_elastic=true  
+        password_reset_elastic=true
       fi
     else
       sleep 1
@@ -147,10 +147,11 @@ if [[ "${SSL_MODE}" == "true" ]]; then
     --elasticsearch.ssl.key=/home/elastic/elasticsearch-${EK_VERSION}/config/certs/instance/instance.key \
     --elasticsearch.ssl.verificationMode=certificate \
     --elasticsearch.serviceAccountToken=${KIBANA_SERVICE_TOKEN}
-  # Start Kibana in SSL Mode
 
 elif [[ "${SSL_MODE}" == "false" ]]; then
-  # Show the connection URLS
+  # ----------------------------
+  # Start Elastic / Kibana [NO-SSL]
+  # ----------------------------
   echo "------- Starting Elasticsearch + Kibana -------"
   echo "       Kibana URL: http://localhost:5601/"
   echo "Elasticsearch URL: http://localhost:9200/"


### PR DESCRIPTION
This PR fixes and cleans up a few things.

---

- Fixed an issue with the Kibana password not being output on first launch on some Arch systems.
- Added compatibility for Kubernetes
- Fixed Syntax issue with `entrypoint.sh#L150`
- Added more clear `README.md` instructions on how to manually reset the password if needed

Extra usage variables and how to reset the password if for some reason you do not see that output when the program starts.


---

*Also I'd suggest updating the Docker image on your page here: https://hub.docker.com/r/nshou/elasticsearch-kibana*